### PR TITLE
MEE6 LeaderBoard取得機能を追加

### DIFF
--- a/cogs/nekok500_mee6.py
+++ b/cogs/nekok500_mee6.py
@@ -1,0 +1,27 @@
+import discord,aiohttp
+from discord.ext import commands
+
+class MEE6(commands.Cog):
+    def __init__(self,bot):
+        self.bot = bot
+        self.session = aiohttp.ClientSession(loop=self.loop)
+    @commands.command()
+    @commands.guild_only()
+    @commands.cooldown(1,5,commands.BucketType.guild)
+    async def levels(self,ctx,start=1,end=0):
+        start -= 1
+        async with self.bot.session.get("https://mee6.xyz/api/plugins/levels/leaderboard/{0}".format(ctx.guild.id)) as resp:
+            js = await resp.json()
+            if "status_code" in js:
+                if js["status_code"] == 404:
+                    await ctx.send(embed=discord.Embed(ut.textto("mee6-notfound")))
+                    return
+
+            else:
+                l = []
+                for row in js["players"][start:end]:
+                    l.append("{0}: {1}Lv {2}/{3}exp".format(ctx.guild.get_member(row["id"]).name if not ctx.guild.get_member(row["id"]) is None else (row["username"] + "#" + row["discriminator"])
+                        ,row["level"],row["detailed_xp"][0],row["detailed_xp"][1]))
+                await ctx.send(embed=discord.Embed(title="MEE6 LeaderBoard",description="\n".join(l)),color=0x05FF05)
+def setup(bot):
+    bot.add_cog(MEE6(bot))

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -263,7 +263,7 @@
     "ssm-seeyou":"サーバーから退出したとき",
     "ssm-set":"設定しました！",
     "ssm-not":"不備があります。`s-help setsysmsg`で確認してください！",
-    
+
     "serverinfo-afkch":"afkチャンネル",
     "serverinfo-afktimeout":"afkタイムアウト",
     "ci-None":"なし",
@@ -365,7 +365,7 @@
     "twi-twi":"ツイート",
     "twi-see":"このツイートを見る",
     "twi-error":"取得できませんでした。",
-    
+
     "game1-join-anyone":"ゲームプレイの招待があります！リアクションして参加しましょう！",
     "game1-vs-et":"near21(対人)",
     "game1-vs-ed":"1P:{0}\n2P:{1}\n21に近づけましょう！",
@@ -629,5 +629,7 @@
     "ranklev-outsideg":"サーバー外のユーザー",
     "ranklev-lenover":"表示できてない分あり",
 
-    "playinginfo-custom_status":"カスタムステータス"
+    "playinginfo-custom_status":"カスタムステータス",
+
+    "mee6-notfound":"このサーバーは登録されてないってよ"
 }


### PR DESCRIPTION
levelsで実行した鯖のMEE6 LeaderBoardを表示します。
MEE6 APIを使用します(詳細不明)