### PR TITLE
linked-roles機能のメタデータ更新コマンド作成

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -275,6 +275,7 @@ async def on_ready():
             "m10s_role_panel", "m10s_partners", "m10s_remainder", "m10s_set_activity_roles",
 
             "_m10s_api", "takumi_twinotif",
+            "m10s_app_metadata",
             
             # "__part_pjsekai_music_select"
             "slash.pjsekai_music_select", # 思惟奈ちゃんパートナー向け機能-ぱすこみゅ

--- a/cogs/m10s_app_metadata.py
+++ b/cogs/m10s_app_metadata.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+import discord
+from discord.ext import commands
+import asyncio
+from dateutil.relativedelta import relativedelta as rdelta
+import traceback
+import m10s_util as ut
+import textwrap
+
+import config
+import aiohttp
+
+from discord import app_commands
+
+class m10s_app_metadata(commands.Cog):
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    @commands.is_owner()
+    @ut.runnable_check()
+    async def update_role_metadata(self, ctx):
+        json_body = [
+            {
+                "key":"isadmin",
+                "name":"チーム☆思惟奈ちゃん",
+                "description":"思惟奈ちゃん運営である",
+                "type":7
+            },
+            {
+                "key":"isdonate",
+                "name":"思惟奈ちゃんプレミアム会員",
+                "description":"思惟奈ちゃんに寄付を行った、プレミアム会員である",
+                "type":7
+            },
+            {
+                "key":"isverified",
+                "name":"思惟奈ちゃん認証済みアカウント",
+                "description":"思惟奈ちゃん上で、アカウントが認証されている",
+                "type":7
+            },
+            {
+                "key":"gamepoint",
+                "name":"ゲームポイント",
+                "description":"一部ゲームでたまる思惟奈ちゃんゲームポイントを、指定値以上所有している",
+                "type":2
+            }
+        ]
+        headers = {
+            "Authorization": f"Bot {config.BOT_TOKEN}"
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.put(url=f"https://discord.com/api/v10/applications/{config.DISCORD_CLIENT_ID}/role-connections/metadata", json=json_body, headers=headers) as resp:
+                resp.raise_for_status()
+        await ctx.send("> 設定しました。")
+
+    @commands.hybrid_command(description="あなたの接続されているアプリメタデータを更新します。")
+    async def sync_metadata(self, ctx:commands.Context):
+        upf = await self.bot.cursor.fetchone("select oauth_ref_token from users where id=%s", (ctx.author.id,))
+        if upf["oauth_ref_token"]:
+            try:
+                await self.bot.update_connect_metadata(ctx.author.id, upf["oauth_ref_token"], True)
+            except:
+                await ctx.send("失敗しました。\n一度連携を外し、再度連携させてください。", ephemeral=True)
+            else:
+                await ctx.send("完了しました。", ephemeral=True)
+        else:
+            await ctx.send("失敗しました。\nまだアプリ連携が行われていません。linked-rolesメニューから、思惟奈ちゃんの連携が有効なロールを探して連携してください。", ephemeral=True)
+
+
+async def setup(bot):
+    await bot.add_cog(m10s_app_metadata(bot))

--- a/cogs/m10s_owner.py
+++ b/cogs/m10s_owner.py
@@ -8,12 +8,53 @@ import traceback
 import m10s_util as ut
 import textwrap
 
+import config
+import aiohttp
+
 from discord import app_commands
 
 class owner(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
+
+    @commands.command()
+    @commands.is_owner()
+    @ut.runnable_check()
+    async def update_role_metadata(self, ctx):
+        json_body = [
+            {
+                "key":"isadmin",
+                "name":"チーム☆思惟奈ちゃん",
+                "description":"思惟奈ちゃん運営である",
+                "type":7
+            },
+            {
+                "key":"isdonate",
+                "name":"思惟奈ちゃんプレミアム会員",
+                "description":"思惟奈ちゃんに寄付を行った、プレミアム会員である",
+                "type":7
+            },
+            {
+                "key":"isverified",
+                "name":"思惟奈ちゃん認証済みアカウント",
+                "description":"思惟奈ちゃん上で、アカウントが認証されている",
+                "type":7
+            },
+            {
+                "key":"gamepoint",
+                "name":"ゲームポイント",
+                "description":"一部ゲームでたまる思惟奈ちゃんゲームポイントを、指定値以上所有している",
+                "type":2
+            }
+        ]
+        headers = {
+            "Authorization": f"Bot {config.BOT_TOKEN}"
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.put(url=f"https://discord.com/api/v10/applications/{config.DISCORD_CLIENT_ID}/role-connections/metadata", json=json_body, headers=headers) as resp:
+                resp.raise_for_status()
+        await ctx.send("> 設定しました。")
 
     @commands.command()
     @commands.is_owner()

--- a/cogs/m10s_owner.py
+++ b/cogs/m10s_owner.py
@@ -21,44 +21,6 @@ class owner(commands.Cog):
     @commands.command()
     @commands.is_owner()
     @ut.runnable_check()
-    async def update_role_metadata(self, ctx):
-        json_body = [
-            {
-                "key":"isadmin",
-                "name":"チーム☆思惟奈ちゃん",
-                "description":"思惟奈ちゃん運営である",
-                "type":7
-            },
-            {
-                "key":"isdonate",
-                "name":"思惟奈ちゃんプレミアム会員",
-                "description":"思惟奈ちゃんに寄付を行った、プレミアム会員である",
-                "type":7
-            },
-            {
-                "key":"isverified",
-                "name":"思惟奈ちゃん認証済みアカウント",
-                "description":"思惟奈ちゃん上で、アカウントが認証されている",
-                "type":7
-            },
-            {
-                "key":"gamepoint",
-                "name":"ゲームポイント",
-                "description":"一部ゲームでたまる思惟奈ちゃんゲームポイントを、指定値以上所有している",
-                "type":2
-            }
-        ]
-        headers = {
-            "Authorization": f"Bot {config.BOT_TOKEN}"
-        }
-        async with aiohttp.ClientSession() as session:
-            async with session.put(url=f"https://discord.com/api/v10/applications/{config.DISCORD_CLIENT_ID}/role-connections/metadata", json=json_body, headers=headers) as resp:
-                resp.raise_for_status()
-        await ctx.send("> 設定しました。")
-
-    @commands.command()
-    @commands.is_owner()
-    @ut.runnable_check()
     async def get_ch_id(self, ctx, cnm: str):
         text = [f"{str(ch)} ({ch.id})" for ch in ctx.guild.channels if cnm in str(ch)]
         t = "\n".join(text)


### PR DESCRIPTION
discordの新機能「linked-roles」で使用可能な情報提供のため、チーム☆思惟奈ちゃんであるか、思惟奈ちゃんの有料会員かどうか、思惟奈ちゃんの認証済みアカウントであるか、ゲームポイントの4つの情報をメタデータに記録する宣言を行うコマンド。
is_owner指定があるので一般利用者からは使用不可