### PR TITLE
エラーログを元に2箇所のバグを修正

### DIFF
--- a/cogs/hybrid/m10s_levels.py
+++ b/cogs/hybrid/m10s_levels.py
@@ -338,7 +338,10 @@ class levels(commands.Cog):
         #gs = await self.bot.cursor.fetchone()
         rewards = json.loads(gs["reward"])
         if rl is None:
-            del rewards[str(lv)]
+            if str(lv) in rewards:
+                del rewards[str(lv)]
+            else:
+                return await ctx.send("エラー: そのレベルには報酬が設定されていません。")
         else:
             rid = rl.id
             rewards[str(lv)] = rid

--- a/cogs/m10s_other.py
+++ b/cogs/m10s_other.py
@@ -150,7 +150,7 @@ class other(commands.Cog):
         if await ctx.user_lang() == "ja":
             if await ctx._(f"er-{it}") == "":
                 await ctx.send(await ctx._("er-?"))
-                await self.bot.fetch_channel(993565802030698627).send(f"> 思惟奈のわからない絵文字があったよ。`{str(emoji)}`")
+                await (await self.bot.fetch_channel(993565802030698627)).send(f"> 思惟奈のわからない絵文字があったよ。`{str(emoji)}`")
             else:
                 await ctx.send(await ctx._(f"er-{it}"))
         else:


### PR DESCRIPTION
・絵文字コマンドで登録されていない絵文字を送信されたときの開発者用ログを送信する際にエラーが出る問題
(ErrorId: 1168217741010931806)
・レベル報酬設定・解除コマンドで存在しない報酬の解除をしようとしたときにエラーが出る問題
(ErrorId: 1166332881283579994)
以上2つのバグを修正しました。