### PR TITLE
特殊グローバルチャットへの対応忘れを修正

### DIFF
--- a/cogs/hybrid/m10s_re_gchat.py
+++ b/cogs/hybrid/m10s_re_gchat.py
@@ -512,16 +512,17 @@ class m10s_re_gchat(commands.Cog):
         if gchat_info:
 
             if upf["agree_to_gchat_tos"] == 0:
-                check_msg = await m.reply("グローバルチャットを利用するには[グローバルチャット利用規約](<https://home.sina-chan.com/legal/gchat-tos>)への同意が必要です。\n利用規約をご確認いただき、同意いただける場合は、✅を押してください。")
-                await check_msg.add_reaction("✅")
-                try:
-                    await self.bot.wait_for("reaction_add", check = lambda r,u: m.author.id == u.id and r.message.id == check_msg.id and str(r.emoji) == "✅", timeout=600)
-                except asyncio.TimeoutError:
-                    return await check_msg.edit(content="> タイムアウトしました。再度グローバルチャットを利用しようとした際に、再度、同意メッセージが表示されます。")
-                else:
-                    await self.bot.cursor.execute(
-                        "UPDATE users SET agree_to_gchat_tos = %s WHERE id = %s", (1, m.author.id))
-                    return await check_msg.edit(content="同意処理が完了しました。\n次のメッセージよりグローバルチャットに送信されます。")
+                if not gchat_info["connected_to"] in self.without_react:
+                    check_msg = await m.reply("グローバルチャットを利用するには[グローバルチャット利用規約](<https://home.sina-chan.com/legal/gchat-tos>)への同意が必要です。\n利用規約をご確認いただき、同意いただける場合は、✅を押してください。")
+                    await check_msg.add_reaction("✅")
+                    try:
+                        await self.bot.wait_for("reaction_add", check = lambda r,u: m.author.id == u.id and r.message.id == check_msg.id and str(r.emoji) == "✅", timeout=600)
+                    except asyncio.TimeoutError:
+                        return await check_msg.edit(content="> タイムアウトしました。再度グローバルチャットを利用しようとした際に、再度、同意メッセージが表示されます。")
+                    else:
+                        await self.bot.cursor.execute(
+                            "UPDATE users SET agree_to_gchat_tos = %s WHERE id = %s", (1, m.author.id))
+                        return await check_msg.edit(content="同意処理が完了しました。\n次のメッセージよりグローバルチャットに送信されます。")
 
             if upf["gban"] == 1:
                 if not gchat_info["connected_to"] in self.without_react:


### PR DESCRIPTION
リアクションやグローバルチャットBANバイパス等、利用者にグローバルチャットであることを感じさせずに使用させているプライベート仕様のチャンネルにて、規約同意に関するメッセージが表示され、規約同意を必須としていた対応忘れを修正