### PR TITLE
Potential fix for code scanning alert no. 266: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_syntax.yml
+++ b/.github/workflows/check_syntax.yml
@@ -2,6 +2,9 @@ name: Check Checks
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/266](https://github.com/SinaKitagami/program-team/security/code-scanning/266)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
