### PR TITLE
Potential fix for code scanning alert no. 687: Unreachable code

### DIFF
--- a/cogs/apple_foc.py
+++ b/cogs/apple_foc.py
@@ -37,7 +37,6 @@ class AppleFOCCog(commands.Cog):
         e = discord.Embed(title="オンライン隠し", description=member.mention,
                           timestamp=datetime.datetime.now(datetime.timezone.utc))
         return
-        await logc.send(embed=e)
 
     async def run(self, member):
         if member.bot or not await self.is_offline(member):


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/687](https://github.com/SinaKitagami/program-team/security/code-scanning/687)

To fix the issue, we need to remove the unreachable code on line 40 (`await logc.send(embed=e)`) since it will never be executed due to the preceding `return` statement. This will make the code cleaner and easier to understand without altering its functionality. If the intention was to execute the `await logc.send(embed=e)` statement, the `return` statement on line 39 would need to be removed or modified. However, based on the current structure of the code, it seems the `return` statement is intentional, and the unreachable code should simply be removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
