### PR TITLE
Potential fix for code scanning alert no. 577: Variable defined multiple times

### DIFF
--- a/cogs/m10s_other.py
+++ b/cogs/m10s_other.py
@@ -272,7 +272,6 @@ class other(commands.Cog):
                     ml.remove(tmp)
                 gl.append(ogl)
                 ogl = []
-                tmp = "hoge"
             gtxt = "\n".join([f"{'、'.join(m)}" for m in gl])
             ng = ",".join(ml)
             await ctx.send(embed=discord.Embed(title=await ctx._("rg-title"), description=await ctx._("rg-desc", gtxt, ng), color=self.bot.ec))


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/577](https://github.com/SinaKitagami/program-team/security/code-scanning/577)

To fix the issue, we should remove the redundant assignment to `tmp` on line 275. This will clean up the code without altering its functionality, as the value assigned to `tmp` on line 275 is overwritten before it is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
