### PR TITLE
Potential fix for code scanning alert no. 576: Variable defined multiple times

### DIFF
--- a/cogs/m10s_other.py
+++ b/cogs/m10s_other.py
@@ -264,7 +264,6 @@ class other(commands.Cog):
             ml = [m.mention for m in role.members if not m.bot]
             ogl = []
             gl = []
-            tmp = "hoge"
             while len(ml) >= cou:
                 for i in range(cou):
                     tmp = random.choice(ml)


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/576](https://github.com/SinaKitagami/program-team/security/code-scanning/576)

To fix the issue, we will remove the redundant assignment of `"hoge"` to the variable `tmp` on line 267. This change ensures that `tmp` is only assigned a value when it is actually used on line 270. No additional changes are required, as the removal does not affect the logic or functionality of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
