### PR TITLE
Potential fix for code scanning alert no. 699: Potentially uninitialized local variable

### DIFF
--- a/cogs/pf9_symmetry.py
+++ b/cogs/pf9_symmetry.py
@@ -43,6 +43,8 @@ class Symmetry(commands.Cog):
             elif side == 3:
                 tmp1 = img.crop(
                     (0, img.size[0] // 2, img.size[0], img.size[1]))
+            else:
+                raise ValueError(f"Invalid value for 'side': {side}. Expected 0, 1, 2, or 3.")
             if side == 0 or side == 1:
                 tmp2 = ImageOps.mirror(tmp1)
                 dst = Image.new(


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/699](https://github.com/SinaKitagami/program-team/security/code-scanning/699)

To fix the issue, we will add a fallback `else` block after the `if-elif` chain to handle cases where `side` is not one of the expected values (0, 1, 2, or 3). In this fallback block, we will raise a `ValueError` with an appropriate error message. This ensures that `tmp1` is always initialized or the function exits with a clear error if `side` is invalid.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
