### PR TITLE
Potential fix for code scanning alert no. 698: Potentially uninitialized local variable

### DIFF
--- a/cogs/pf9_symmetry.py
+++ b/cogs/pf9_symmetry.py
@@ -33,6 +33,7 @@ class Symmetry(commands.Cog):
         async with ctx.channel.typing():
             await image.save("image.png")
             img = Image.open('image.png')
+            tmp1 = None  # Default initialization
             if side == 0:
                 tmp1 = img.crop((0, 0, img.size[0] // 2, img.size[1]))
             elif side == 1:
@@ -43,6 +44,8 @@ class Symmetry(commands.Cog):
             elif side == 3:
                 tmp1 = img.crop(
                     (0, img.size[0] // 2, img.size[0], img.size[1]))
+            else:
+                raise ValueError(f"Invalid value for side: {side}")
             if side == 0 or side == 1:
                 tmp2 = ImageOps.mirror(tmp1)
                 dst = Image.new(


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/698](https://github.com/SinaKitagami/program-team/security/code-scanning/698)

To fix the issue, we need to ensure that `tmp1` is always initialized before it is used. This can be achieved by adding a default initialization for `tmp1` before the conditional block. Additionally, we can add an `else` clause to handle unexpected values of `side` and raise an appropriate error. This ensures that the code is robust and avoids potential runtime errors.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
