### PR TITLE
Potential fix for code scanning alert no. 697: Potentially uninitialized local variable

### DIFF
--- a/m10s_util.py
+++ b/m10s_util.py
@@ -62,6 +62,7 @@ async def wait_message_return(ctx, stext, sto, tout=60):
 def get_vmusic(bot, member):
     mg = None
     mn = None
+    ml = False  # Default value for ml
     for v in bot.voice_clients:
         vm_m = [i for i in v.channel.members if i.id == member.id]
         if not vm_m == []:


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/697](https://github.com/SinaKitagami/program-team/security/code-scanning/697)

To fix the issue, we need to ensure that `ml` is always initialized before it is used. The best approach is to assign a default value to `ml` at the beginning of the function. This ensures that `ml` has a valid value even if the `for` loop does not execute or the `try` block fails. The default value should reflect the intended behavior of the function when `ml` is not explicitly set.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
