### PR TITLE
Potential fix for code scanning alert no. 695: Potentially uninitialized local variable

### DIFF
--- a/cogs/slash/m10s_messageinfo.py
+++ b/cogs/slash/m10s_messageinfo.py
@@ -74,6 +74,7 @@ class m10s_messageinfo(commands.Cog):
             elif isinstance(msg.channel, discord.Thread):
                 chtype = f"{msg.channel.name}({msg.channel.id}):テキストチャンネル内スレッド"
             else:
+                logging.warning(f"Unexpected channel type: {type(msg.channel)}")
                 chtype = "Unknown channel type"
             e.add_field(name="メッセージの送信先チャンネル", value=chtype, inline=False)
 

--- a/cogs/slash/m10s_messageinfo.py
+++ b/cogs/slash/m10s_messageinfo.py
@@ -74,7 +74,11 @@ class m10s_messageinfo(commands.Cog):
             elif isinstance(msg.channel, discord.Thread):
                 chtype = f"{msg.channel.name}({msg.channel.id}):テキストチャンネル内スレッド"
             else:
-                logging.warning(f"Unexpected channel type: {type(msg.channel)}")
+                logging.warning(
+                    f"Unexpected channel type: {type(msg.channel)}, "
+                    f"Channel ID: {getattr(msg.channel, 'id', 'Unknown ID')}, "
+                    f"Channel Name: {getattr(msg.channel, 'name', 'Unknown Name')}"
+                )
                 chtype = "Unknown channel type"
             e.add_field(name="メッセージの送信先チャンネル", value=chtype, inline=False)
 

--- a/cogs/slash/m10s_messageinfo.py
+++ b/cogs/slash/m10s_messageinfo.py
@@ -73,6 +73,8 @@ class m10s_messageinfo(commands.Cog):
                 chtype = f"{msg.channel.name}({msg.channel.id}):ボイスチャンネル内テキストチャット"
             elif isinstance(msg.channel, discord.Thread):
                 chtype = f"{msg.channel.name}({msg.channel.id}):テキストチャンネル内スレッド"
+            else:
+                chtype = "Unknown channel type"
             e.add_field(name="メッセージの送信先チャンネル", value=chtype, inline=False)
 
             if msg.type == discord.MessageType.reply:


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/695](https://github.com/SinaKitagami/program-team/security/code-scanning/695)

To fix the issue, we need to ensure that `chtype` is always initialized before it is used. This can be achieved by adding an `else` block to handle cases where `msg.channel` does not match any of the specified types (`discord.TextChannel`, `discord.VoiceChannel`, `discord.Thread`). In the `else` block, we can assign a default value to `chtype`, such as "Unknown channel type".

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
