### PR TITLE
Potential fix for code scanning alert no. 694: Potentially uninitialized local variable

### DIFF
--- a/cogs/m10s_direct_msg.py
+++ b/cogs/m10s_direct_msg.py
@@ -35,7 +35,8 @@ class m10s_direct_msg(commands.Cog):
             try:
                 r,u = await self.bot.wait_for("reaction_add", timeout=30, check=lambda r,u:u.id == ctx.author.id and str(r.emoji) in ["⭕","❌"])
             except asyncio.TimeoutError:
-                await m.edit("タイムアウトしました。再度操作を行ってください。")
+                await m.edit(content="タイムアウトしました。再度操作を行ってください。")
+                return
             if str(r.emoji) == "⭕":
                 try:
                     await user.send(content)


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/694](https://github.com/SinaKitagami/program-team/security/code-scanning/694)

To fix the issue, we need to ensure that the variable `r` is always initialized before it is used. This can be achieved by adding a fallback mechanism in the `except` block for `asyncio.TimeoutError`. Specifically, we can return early from the function or handle the timeout scenario in a way that avoids referencing `r` and `u` when they are not initialized. This ensures that the code does not attempt to access uninitialized variables.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
