### PR TITLE
Potential fix for code scanning alert no. 693: Potentially uninitialized local variable

### DIFF
--- a/cogs/hybrid/info_check.py
+++ b/cogs/hybrid/info_check.py
@@ -490,6 +490,7 @@ class info_check(commands.Cog):
                 "playinginfo-doing"), description=f"{lmsc['guild'].name}で、思惟奈ちゃんを使って[{lmsc['name']}]({lmsc['url']} )を聞いています", color=info.color)
             activs.append("思惟奈ちゃんでの音楽鑑賞")
             embeds.append(embed)
+        embed = discord.Embed(title=await ctx._("playinginfo-doing"), description=await ctx._("playinginfo-noActivity"), color=discord.Color.default())
         if info.activity is None:
             if str(info.status) == "offline":
                 embed = discord.Embed(title=await ctx._(

--- a/cogs/hybrid/info_check.py
+++ b/cogs/hybrid/info_check.py
@@ -530,8 +530,6 @@ class info_check(commands.Cog):
                             "playinginfo-doing"), description=await ctx._("playinginfo-onlyPhone"), color=info.color)
                         activs.append("スマートフォンクライアント")
                     else:
-                        embed = discord.Embed(title=await ctx._(
-                            "playinginfo-doing"), description=await ctx._("playinginfo-noActivity"), color=info.color)
                         activs.append("なにもしてない…のかな？")
             activ = info.activity
             embed.set_author(name=info.display_name,


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/693](https://github.com/SinaKitagami/program-team/security/code-scanning/693)

To fix the issue, we need to ensure that `embed` is always initialized before it is used. A good approach is to initialize `embed` with a default value at the beginning of the relevant block. This ensures that even if none of the conditional branches execute, `embed` will have a valid value. The default value should be meaningful and consistent with the context of the function.

In this case, initializing `embed` with a default `discord.Embed` object with a generic title and description would be appropriate. This ensures that the code does not break and provides a fallback behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
