### PR TITLE
Potential fix for code scanning alert no. 575: Comparison using is when operands support `__eq__`

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -498,7 +498,7 @@ async def gahash(message, gs):
         pass
     if "shash" not in json.loads(gs["lockcom"]):
         ch = json.loads(gs["hash"])
-        if ch is not []:
+        if ch != []:
             menchan = message.channel_mentions
             for sch in menchan:
                 if sch.id in ch:

--- a/bot.py
+++ b/bot.py
@@ -498,7 +498,7 @@ async def gahash(message, gs):
         pass
     if "shash" not in json.loads(gs["lockcom"]):
         ch = json.loads(gs["hash"])
-        if ch != []:
+        if ch:
             menchan = message.channel_mentions
             for sch in menchan:
                 if sch.id in ch:


### PR DESCRIPTION
Potential fix for [https://github.com/SinaKitagami/program-team/security/code-scanning/575](https://github.com/SinaKitagami/program-team/security/code-scanning/575)

To fix the issue, replace the `is not []` comparison with `!= []`. This ensures that the code checks whether `ch` is not an empty list based on value equivalence, which is the correct and intended behavior. The change should be made on line 501 of the provided code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
