### PR TITLE
Tier2メトリクス(コマンド実行数・レイテンシ・エラー率)を追加

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,13 +11,23 @@ import wikipedia
 import wikidata.client
 import asyncio
 import datetime
+import time
 import traceback
 
 import aiohttp
 import aiosqlite
 import database
 
-from metrics import start_metrics_server, BOT_READY, BOT_GUILD_COUNT, BOT_LATENCY_SECONDS, BOT_SHARD_COUNT
+from metrics import (
+    start_metrics_server,
+    BOT_READY,
+    BOT_GUILD_COUNT,
+    BOT_LATENCY_SECONDS,
+    BOT_SHARD_COUNT,
+    BOT_COMMANDS_TOTAL,
+    BOT_COMMAND_ERRORS_TOTAL,
+    BOT_COMMAND_LATENCY_SECONDS,
+)
 
 from twitter import *
 from dateutil.relativedelta import relativedelta as rdelta
@@ -649,6 +659,7 @@ async def rtopic(ctx, ch:discord.TextChannel=None):
 
 @bot.event
 async def on_command(ctx:commands.Context):
+    ctx._t2_start = time.monotonic()
     if ctx.interaction:return
     ch = await bot.fetch_channel(693048961107230811)
     e = discord.Embed(title=f"prefixコマンド:{ctx.command.full_parent_name}の実行",
@@ -666,6 +677,15 @@ async def on_command(ctx:commands.Context):
     e.add_field(name="実行チャンネル", value=getattr(ctx.channel,"name", "DMでの実行"))
     e.timestamp = ctx.message.created_at
     await ch.send(embed=e)
+
+@bot.event
+async def on_command_completion(ctx:commands.Context):
+    command_name = ctx.command.qualified_name
+    cmd_type = "slash" if ctx.interaction else "prefix"
+    BOT_COMMANDS_TOTAL.labels(command=command_name, type=cmd_type).inc()
+    start = getattr(ctx, "_t2_start", None)
+    if start is not None:
+        BOT_COMMAND_LATENCY_SECONDS.labels(command=command_name, type=cmd_type).observe(time.monotonic() - start)
 
 @bot.event
 async def on_interaction(interaction:discord.Interaction):
@@ -698,6 +718,9 @@ async def on_command_error(ctx, error):
     el"""
     if isinstance(error, commands.HybridCommandError):
         error = error.original
+    command_name = ctx.command.qualified_name if ctx.command else "(unknown)"
+    cmd_type = "slash" if ctx.interaction else "prefix"
+    BOT_COMMAND_ERRORS_TOTAL.labels(command=command_name, type=cmd_type, error_type=type(error).__name__).inc()
     if isinstance(error, (commands.CommandOnCooldown, app_commands.CommandOnCooldown)):
         # クールダウン
         embed = discord.Embed(title=await ctx._("cmd-error-t"), description=await ctx._(

--- a/metrics.py
+++ b/metrics.py
@@ -1,9 +1,25 @@
-from prometheus_client import start_http_server, Gauge
+from prometheus_client import start_http_server, Gauge, Counter, Histogram
 
 BOT_READY = Gauge("sina_chan_ready", "1 if the bot is ready, 0 otherwise")
 BOT_GUILD_COUNT = Gauge("sina_chan_guild_count", "Number of guilds the bot is in")
 BOT_LATENCY_SECONDS = Gauge("sina_chan_latency_seconds", "Discord gateway latency")
 BOT_SHARD_COUNT = Gauge("sina_chan_shard_count", "Number of shards")
+
+BOT_COMMANDS_TOTAL = Counter(
+    "sina_chan_commands_total",
+    "Number of commands that completed successfully",
+    ["command", "type"],
+)
+BOT_COMMAND_ERRORS_TOTAL = Counter(
+    "sina_chan_command_errors_total",
+    "Number of commands that ended in an error",
+    ["command", "type", "error_type"],
+)
+BOT_COMMAND_LATENCY_SECONDS = Histogram(
+    "sina_chan_command_latency_seconds",
+    "Command execution time in seconds, from invocation to successful completion",
+    ["command", "type"],
+)
 
 
 def start_metrics_server(port: int = 9200) -> None:


### PR DESCRIPTION
## 📝 変更内容

`sina-chan-monitoring`リポジトリの拡張候補F-1（`docs/expansion_candidates.md`）に対応する変更です。既存のTier 1メトリクス（`sina_chan_ready`等）に加えて、コマンド単位の実行状況を可視化するためのメトリクスを追加します。

- `metrics.py`：`sina_chan_commands_total`（コマンド正常完了数）・`sina_chan_command_errors_total`（エラー数）・`sina_chan_command_latency_seconds`（実行時間）の3メトリクスを追加
- `bot.py`：`on_command`（開始時刻の保持を追加）・`on_command_completion`（新設）・`on_command_error`（エラー計上を追加）の3イベントにのみ計装コードを追加。各cog（`cogs/`配下）は一切変更していません

## 👀 レビューしてほしい点

- `on_command`で`ctx.interaction`による早期リターンより前に`ctx._t2_start = time.monotonic()`を置いている点（slash経由のhybrid_commandでも計測対象にするため、既存の早期リターンより前段に配置しています）
- `on_command_error`で`ctx.command`が`None`になりうるケース（`CommandNotFound`等）へのフォールバック（`"(unknown)"`）
- 純粋な`app_commands.command`/`app_commands.context_menu`（`shutdown`・`message info`・`spread spoiler`の3件）は`discord.ext.commands`のイベントを経由しないため、今回のスコープ外としています

## 💬 補足

- discord.py 2.7.1（本リポジトリの固定バージョン）のソースコード（`ext/commands/hybrid.py`・`ext/commands/bot.py`・`ext/commands/core.py`）を確認し、hybrid_commandがslash/prefixいずれの呼び出し経路でも`command`/`command_completion`/`command_error`イベントを一元的に発火することを検証済みです
- 追加した計装ロジックは、実際の discord.py 2.7.1 / prometheus_client 0.26.0 を使った単体テスト（prefix実行・slash実行・エラー時のラベル付け・`ctx.command is None`時のフォールバック・レイテンシ計測の5パターン）で動作確認済みです
- 既存のDiscordへの実行ログ通知処理（Embed送信）には変更を加えていません


---
_Generated by [Claude Code](https://claude.ai/code/session_0143qzbqtUKtFyhcEBZKh8Cc)_